### PR TITLE
Fix plot failing due to displaying Tuple

### DIFF
--- a/notebooks/1-MDPs.jl
+++ b/notebooks/1-MDPs.jl
@@ -436,7 +436,7 @@ function plot_transition_probability(distr)
 	@info probs
 	cmap_probs = ColorScheme([colorant"#B3BCDB", colorant"#4063D8"])
 	bar(probs,
-		xformatter = x->1 <= x <= length(xtick_states) ? xtick_states[Int(x)] : "",
+		xformatter = x->1 <= x <= length(xtick_states) ? string(xtick_states[Int(x)]) : "",
 		label=false,
 		aspect_ratio=5,
 		group=xtick_states,


### PR DESCRIPTION
It appears the display is failing to print a `Tuple{Int, Int}` value, so I just wrapped it around with a `string()`
